### PR TITLE
Implement Gulp Lint Task

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-connect": "^5.0.0",
+    "gulp-eslint": "^3.0.1",
     "gulp-jasmine-browser": "1.6.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^2.0.0",


### PR DESCRIPTION
test task now depends on lint task. gulp-eslint set to kill the stream on linter error
![screen shot 2016-09-14 at 10 36 41 am](https://cloud.githubusercontent.com/assets/2809870/18516676/e037bbb2-7a67-11e6-80d3-a0d65c016629.png)
